### PR TITLE
Adds Dependabot project to loops-server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
       - "github-actions"
 
   - package-ecosystem: "docker"
-    directory: "/docker"
+    directory: "/docker/complete"
     schedule:
       interval: daily
       time: '05:00'


### PR DESCRIPTION
As it's really hard to stay up-to-date with all the dependencies, I added the Dependabot project to the loops-server.
[Dependabot code](https://github.com/dependabot/) - [Dependabot documentation](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide)

What is important to do before mergin it in:

-  add the following [labels](https://github.com/joinloops/loops-server/labels) to your project:
   - dependencies
   - npm
   - laravel-composer
   - docker
   - github-actions
   - patch
   - minor
   - major
(I forgot to initially add the labels for patch, minor and major, that's why they are not set in the screenshot below)
   
this is needed, to have better overview in the PRs
<img width="882" height="467" alt="PRs with labels" src="https://github.com/user-attachments/assets/c5e6e5f1-be3c-4448-95c4-bed6d98f115d" />
you can then also easily filter them out in the PR view.

normally I would have added automatic merge, but as there are not  really tests in the project, I would not recommend this.
but if you want this, I can add it (but I would not recommend to  automatic merge for more than patches)

you need then to turn on [Dependabot](https://github.com/joinloops/loops-server/network/updates): -> Insights -> Dependency Graph -> Dependabot

you will now get always PR for the dependencies.

If you want to see only PRs with the label depencies you filter for `label:dependencies` if you want all PRs without dependencies, you filter with `-label:dependencies`