### PR TITLE
Proposal to fix missing remote user search

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -40,6 +40,9 @@ class SearchController extends Controller
 
         $maxPages = 5;
         $type = $validated['type'] ?? 'all';
+        if (Str::startsWith($query, '@')) {
+            $type = 'users';
+        }
 
         $maxItems = match ($type) {
             'top' => 12,
@@ -174,6 +177,12 @@ class SearchController extends Controller
                 ->withQueryString();
 
             $usersData = $users->getCollection();
+            if ($usersData->isEmpty()) {
+                $usersData = $this->getUsers(new SearchRequest([
+                                                               'q' => $query, 
+                                                               'user' => $request->user(),
+                ]))->collection;
+            }
             $pager = $users;
             $nextLaravelCursor = $pager->nextCursor()?->encode();
             $nextCursorToken = CursorToken::encode($nextLaravelCursor, $ctx, $hops + 1);


### PR DESCRIPTION
getUsers is not called from the search field, only the standard search function. This change implements a type assignment if the request starts with @, and calls the getUsers function if the local search returns empty.

As written in Discord I am very new to php programming, so please review carefully. 