### PR TITLE
ActivityPubService Content-Type validation

### DIFF
--- a/app/Services/ActivityPubService.php
+++ b/app/Services/ActivityPubService.php
@@ -101,10 +101,11 @@ class ActivityPubService
             'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
         ];
 
+        /** @var string|null $contentType */
         $contentType = $res->header('Content-Type');
 
         if ($validateContentType) {
-            if (! $contentType) {
+            if ($contentType === null) {
                 return false;
             }
 


### PR DESCRIPTION
`Guzzle's getHeader() returns an array of header values, making [0] correct. Laravel's header() returns a string, making [0] incorrect (gets first character).`