### PR TITLE
Update SearchController.php to fix ONLY_FULL_GROUP_BY mode.

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -285,7 +285,19 @@ class SearchController extends Controller
             })
             ->where('profiles.username', 'like', $escapedQuery.'%')
             ->where('profiles.status', 1)
-            ->groupBy('profiles.id', 'profiles.username', 'profiles.followers')
+            ->groupBy(
+                'profiles.id',
+                'profiles.local',
+                'profiles.name',
+                'profiles.avatar',
+                'profiles.username',
+                'profiles.following',
+                'profiles.followers',
+                'profiles.video_count',
+                'profiles.domain',
+                'profiles.status',
+                'profiles.created_at'
+            )
             ->orderByDesc('is_followed')
             ->orderByDesc('profiles.followers')
             ->cursorPaginate(10)


### PR DESCRIPTION
Error: `"POST /api/v1/search/users HTTP/1.1" 500 44 "https://loops.plus/search?q=https://loops.video/@dansup"`

`Fixed groupBy to include all 11 columns from the select clause, which satisfies MySQL's ONLY_FULL_GROUP_BY mode. MySQL's strict mode (ONLY_FULL_GROUP_BY) requires all non-aggregated columns in SELECT to be in GROUP BY.`