### PR TITLE
[Productifiation] Bugfix - [plugin vite:reporter] was giving errors on build

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -26,11 +26,9 @@ const head = createHead()
 const pinia = createPinia()
 
 // Register global components (excluding pages and layouts)
-Object.entries(import.meta.glob([
-    './**/*.vue',
-    '!./pages/**/*.vue',
-    '!./layouts/**/*.vue'
-], { eager: true })).forEach(([path, definition]) => {
+Object.entries(
+    import.meta.glob(['./**/*.vue', '!./pages/**/*.vue', '!./layouts/**/*.vue'], { eager: true })
+).forEach(([path, definition]) => {
     app.component(
         path
             .split('/')


### PR DESCRIPTION
`[plugin vite:reporter] (!) /Users/sparelaptop/github/loops-server/resources/js/pages/v/index.vue is dynamically imported by /Users/sparelaptop/github/loops-server/resources/js/routes/index.js but also statically imported by /Users/sparelaptop/github/loops-server/resources/js/app.js, dynamic import will not move module into another chunk.`

This also shrinks the size of the final bundle files!
