### PR TITLE
Improvement: include query string in the HTTP signature

### DIFF
--- a/app/Jobs/Federation/DeliverCommentLikeActivity.php
+++ b/app/Jobs/Federation/DeliverCommentLikeActivity.php
@@ -90,7 +90,9 @@ class DeliverCommentLikeActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -99,7 +101,7 @@ class DeliverCommentLikeActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverCommentReplyLikeActivity.php
+++ b/app/Jobs/Federation/DeliverCommentReplyLikeActivity.php
@@ -90,7 +90,9 @@ class DeliverCommentReplyLikeActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -99,7 +101,7 @@ class DeliverCommentReplyLikeActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverCreateCommentActivity.php
+++ b/app/Jobs/Federation/DeliverCreateCommentActivity.php
@@ -93,7 +93,9 @@ class DeliverCreateCommentActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -102,7 +104,7 @@ class DeliverCreateCommentActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverCreateCommentReplyActivity.php
+++ b/app/Jobs/Federation/DeliverCreateCommentReplyActivity.php
@@ -93,7 +93,9 @@ class DeliverCreateCommentReplyActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -102,7 +104,7 @@ class DeliverCreateCommentReplyActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverCreateVideoActivity.php
+++ b/app/Jobs/Federation/DeliverCreateVideoActivity.php
@@ -97,7 +97,9 @@ class DeliverCreateVideoActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -106,7 +108,7 @@ class DeliverCreateVideoActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverDeleteCommentActivity.php
+++ b/app/Jobs/Federation/DeliverDeleteCommentActivity.php
@@ -95,7 +95,9 @@ class DeliverDeleteCommentActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -104,7 +106,7 @@ class DeliverDeleteCommentActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverDeleteCommentReplyActivity.php
+++ b/app/Jobs/Federation/DeliverDeleteCommentReplyActivity.php
@@ -95,7 +95,9 @@ class DeliverDeleteCommentReplyActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -104,7 +106,7 @@ class DeliverDeleteCommentReplyActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverDeleteVideoActivity.php
+++ b/app/Jobs/Federation/DeliverDeleteVideoActivity.php
@@ -95,7 +95,9 @@ class DeliverDeleteVideoActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -104,7 +106,7 @@ class DeliverDeleteVideoActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverFollowRequest.php
+++ b/app/Jobs/Federation/DeliverFollowRequest.php
@@ -71,7 +71,9 @@ class DeliverFollowRequest implements ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -80,7 +82,7 @@ class DeliverFollowRequest implements ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverRejectActivity.php
+++ b/app/Jobs/Federation/DeliverRejectActivity.php
@@ -66,7 +66,9 @@ class DeliverRejectActivity implements ShouldQueue
         }
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         $headers = [
             'Host' => $parsedUrl['host'],
@@ -83,7 +85,7 @@ class DeliverRejectActivity implements ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUndoCommentLikeActivity.php
+++ b/app/Jobs/Federation/DeliverUndoCommentLikeActivity.php
@@ -88,7 +88,9 @@ class DeliverUndoCommentLikeActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -97,7 +99,7 @@ class DeliverUndoCommentLikeActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUndoCommentReplyLikeActivity.php
+++ b/app/Jobs/Federation/DeliverUndoCommentReplyLikeActivity.php
@@ -88,7 +88,9 @@ class DeliverUndoCommentReplyLikeActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -97,7 +99,7 @@ class DeliverUndoCommentReplyLikeActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUndoFollowActivity.php
+++ b/app/Jobs/Federation/DeliverUndoFollowActivity.php
@@ -83,7 +83,9 @@ class DeliverUndoFollowActivity implements ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -92,7 +94,7 @@ class DeliverUndoFollowActivity implements ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUndoFollowRequestActivity.php
+++ b/app/Jobs/Federation/DeliverUndoFollowRequestActivity.php
@@ -71,7 +71,9 @@ class DeliverUndoFollowRequestActivity implements ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -80,7 +82,7 @@ class DeliverUndoFollowRequestActivity implements ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUndoVideoLikeActivity.php
+++ b/app/Jobs/Federation/DeliverUndoVideoLikeActivity.php
@@ -92,7 +92,9 @@ class DeliverUndoVideoLikeActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -101,7 +103,7 @@ class DeliverUndoVideoLikeActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Jobs/Federation/DeliverUpdateVideoActivity.php
+++ b/app/Jobs/Federation/DeliverUpdateVideoActivity.php
@@ -93,7 +93,9 @@ class DeliverUpdateVideoActivity implements ShouldBeUnique, ShouldQueue
         ];
 
         $signatureService = app(HttpSignatureService::class);
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
@@ -102,7 +104,7 @@ class DeliverUpdateVideoActivity implements ShouldBeUnique, ShouldQueue
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 json_encode($activity)
             );
 

--- a/app/Services/DeliveryService.php
+++ b/app/Services/DeliveryService.php
@@ -40,14 +40,16 @@ class DeliveryService
 
         try {
             $privateKey = app(SigningService::class)->getPrivateKey();
-            $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+            $path = $parsedUrl['path'] ?? '/';
+            $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+            $requestPath = $path.$queryString;
 
             $signature = $this->signatureService->sign(
                 $actor->getKeyId(),
                 $privateKey,
                 $headers,
                 'POST',
-                $fullParsedUrl,
+                $requestPath,
                 $body
             );
 

--- a/app/Services/RelayService.php
+++ b/app/Services/RelayService.php
@@ -195,14 +195,16 @@ class RelayService
         ];
 
         $privateKey = $this->signingService->getPrivateKey();
-        $fullParsedUrl = ($parsedUrl['path'] ?? '/').(isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '');
+        $path = $parsedUrl['path'] ?? '/';
+        $queryString = isset($parsedUrl['query']) ? '?'.$parsedUrl['query'] : '';
+        $requestPath = $path.$queryString;
 
         $signature = app(HttpSignatureService::class)->sign(
             $actor->getKeyId(),
             $privateKey,
             $headers,
             'POST',
-            $fullParsedUrl,
+            $requestPath,
             $body
         );
 


### PR DESCRIPTION
`ensures the full path with query parameters is used when computing the HTTP signature, matching the actual HTTP request being sent.`