### PR TITLE
Typo in CommentItem.vue

### DIFF
--- a/resources/js/components/Status/CommentItem.vue
+++ b/resources/js/components/Status/CommentItem.vue
@@ -571,7 +571,7 @@ const isLoadingReplies = computed(() => {
 })
 
 const isLoadingMoreReplies = computed(() => {
-    return commentStore.isLoadingReplies(props.videoId, props.comment.id)
+    return commentStore.isLoadingMoreReplies(props.videoId, props.comment.id)
 })
 
 const hasMoreReplies = computed(() => {


### PR DESCRIPTION
`isLoadingReplies` was copy/pasted or similar and lead to a typo.

<img width="731" height="226" alt="image" src="https://github.com/user-attachments/assets/1a984bc0-27a0-4fda-a8bb-8c9548d909ed" />
