### PR TITLE
Federate height and width for video attachment

### DIFF
--- a/app/Federation/ActivityBuilders/CreateActivityBuilder.php
+++ b/app/Federation/ActivityBuilders/CreateActivityBuilder.php
@@ -86,6 +86,8 @@ class CreateActivityBuilder
                     'mediaType' => 'video/mp4',
                     'url' => $video->mediaUrl(),
                     'name' => $video->alt_text,
+                    'width' => $video->thumbnail_width ?? 720,
+                    'height' => $video->thumbnail_height ?? 1280,
                 ],
             ],
             'likes' => [


### PR DESCRIPTION
using the same values as for preview, should work for now, this is mostly so other backends that don't process media can provide correct aspect ratio information to the frontends