### PR TITLE
Fixing " "/bin/sh -c npm run build" did not complete successfully: exit code: 1" when building Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ COPY --from=node /usr/local/bin /usr/local/bin
 COPY --from=node /usr/local/lib /usr/local/lib
 
 # Install npm dependencies and build assets
+RUN npm install
 ENV NODE_ENV="production"
-RUN npm install 
 RUN npm run build
 
 # Switch back to www-data user


### PR DESCRIPTION
Fixing [Admin]: Build error when updating Docker-based deployment #852  (https://github.com/joinloops/loops-server/issues/852)