### PR TITLE
Published videos can render as broken players due to cached `false` media data

### DIFF
--- a/app/Http/Controllers/EmbedController.php
+++ b/app/Http/Controllers/EmbedController.php
@@ -29,6 +29,12 @@ class EmbedController extends Controller
 
         $res = VideoService::getMediaData($video->id);
 
+        if (! $res) {
+            return response()->view('embed.unavailable', [
+                'theme' => $theme,
+            ]);
+        }
+        
         if ($video->has_audio && $video->sound_id) {
             $res['audio'] = [
                 'cover' => data_get($res, 'account.avatar', '/storage/avatars/default.jpg'),


### PR DESCRIPTION
EmbedController converts a cached false value into a broken array, resulting in embed players with empty video source URLs.