### PR TITLE
Embed player @mention links lead to 404 or wrong page because profile URL is missing '/@'

### DIFF
--- a/resources/views/embed/player.blade.php
+++ b/resources/views/embed/player.blade.php
@@ -33,7 +33,7 @@
         return '<a href="' . e(url('/tag/' . $m[1])) . '" target="_blank" rel="noopener">#' . e($m[1]) . '</a>';
     }, $captionHtml);
     $captionHtml = preg_replace_callback('/@([A-Za-z0-9_\.]+)/', function ($m) {
-        return '<a href="' . e(url('/' . $m[1])) . '" target="_blank" rel="noopener">@' . e($m[1]) . '</a>';
+        return '<a href="' . e(url('/@' . $m[1])) . '" target="_blank" rel="noopener">@' . e($m[1]) . '</a>';
     }, $captionHtml);
 @endphp
 


### PR DESCRIPTION
Bug: The embed player caption @mention autolinker builds links with url('/' . $m[1]) (missing the required /@ prefix).