### PR TITLE
Update Dockerfile - Nginx to FrankenPHP + NodeJS 24 to 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,9 @@ RUN chown -R www-data:www-data /var/www/html \
     && find /var/www/html -type d -exec chmod 755 {} \; \
     && chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache
 
-# Install composer dependencies (no-dev recommended for production)
-RUN composer install --no-ansi --no-interaction --no-dev --optimize-autoloader
+# Install composer dependencies 
+## TODO add "--no-dev" for production. Currently breaks due to Pail.
+RUN composer install --no-ansi --no-interaction --optimize-autoloader
 
 # Copy Node.js binaries/libraries from node stage
 COPY --from=node /usr/local/bin /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 # Node.js stage for building assets
-FROM node:24-trixie-slim AS node
-# PHP base image
-FROM serversideup/php:8.4-fpm-nginx
+FROM node:26-trixie-slim AS node
+# PHP base image — FrankenPHP (includes Caddy built-in)
+FROM serversideup/php:8.4-frankenphp
 
-# Set working directory
 WORKDIR /var/www/html
 
-# Switch to root to install packages
 USER root
 
-# Install system dependencies and PHP extensions
+# Install system dependencies
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     libvips42 \
@@ -19,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PHP extensions using the built-in helper
+# Install PHP extensions
 RUN install-php-extensions \
     bcmath \
     ctype \
@@ -48,8 +46,8 @@ RUN chown -R www-data:www-data /var/www/html \
     && find /var/www/html -type d -exec chmod 755 {} \; \
     && chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache
 
-# Install composer dependencies
-RUN composer install --no-ansi --no-interaction --optimize-autoloader
+# Install composer dependencies (no-dev recommended for production)
+RUN composer install --no-ansi --no-interaction --no-dev --optimize-autoloader
 
 # Copy Node.js binaries/libraries from node stage
 COPY --from=node /usr/local/bin /usr/local/bin
@@ -60,8 +58,8 @@ RUN npm install
 ENV NODE_ENV="production"
 RUN npm run build
 
-# Switch back to www-data user
 USER www-data
 
-# Expose port 8080 (default for serversideup/php)
+# FrankenPHP: 8080 HTTP, 8443 HTTPS
 EXPOSE 8080
+EXPOSE 8443


### PR DESCRIPTION
Moved to FrankenPHP - Caddy for better performance, HTTP3 & ZSTD support.

Reference https://serversideup.net/open-source/docker-php/docs/image-variations/frankenphp

Tested on https://loops.plus