### PR TITLE
Fix Build-Error when creating Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=node /usr/local/lib /usr/local/lib
 
 # Install npm dependencies and build assets
 ENV NODE_ENV="production"
-RUN npm install
+RUN npm install --include=dev
 RUN npm run build
 
 USER www-data


### PR DESCRIPTION
Fixed Dockerfile Build-Error "Target horizon: failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1"

Adding

RUN npm install --include=dev

to build process.