### PR TITLE
Fix remote search for bare fediverse handles (user@domain)

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -409,7 +409,7 @@ class SearchController extends Controller
 
     protected function isRemoteQuery(string $query): bool
     {
-        if (preg_match('/^@?[a-zA-Z0-9_]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/', $query)) {
+        if (preg_match('/^@?[a-zA-Z0-9_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/', $query)) {
             return true;
         }
 
@@ -698,10 +698,6 @@ class SearchController extends Controller
             ]);
         }
 
-        $validUrl = app(SanitizeService::class)->url($query, true, false);
-
-        abort_if(! $validUrl, 403, 'Invalid url');
-
         if (! filter_var($query, FILTER_VALIDATE_URL)) {
             $cleanQuery = Str::of($query)->startsWith('@') ? Str::substr($query, 1) : $query;
 
@@ -744,6 +740,14 @@ class SearchController extends Controller
                 ],
             ]);
         }
+
+        // URLs are validated against SSRF/sanitize rules before resolving.
+        // Bare fediverse handles (user@domain) are resolved via webfinger in the
+        // branch above and must skip this gate — url() requires an https:// URL,
+        // so a handle would otherwise 403 "Invalid url" before it can resolve.
+        $validUrl = app(SanitizeService::class)->url($query, true, false);
+
+        abort_if(! $validUrl, 403, 'Invalid url');
 
         $result = $this->resolveUrl($request, $query, $currentUserId);
 

--- a/tests/Feature/RemoteSearchHandleTest.php
+++ b/tests/Feature/RemoteSearchHandleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Services\WebfingerService;
+use Tests\TestCase;
+
+/**
+ * Covers SearchController::remoteLookup() — that a bare fediverse handle
+ * (user@domain) reaches WebFinger resolution instead of being rejected by the
+ * URL-sanitisation gate, while real URLs are still validated for SSRF.
+ *
+ * No database is touched: the acting user is built with make() (auth via
+ * actingAs() does not require persistence) and WebfingerService is mocked, so
+ * the handle path short-circuits before any query runs.
+ */
+class RemoteSearchHandleTest extends TestCase
+{
+    private function actingUser(): User
+    {
+        // profile_id is read (typed int) but, with WebfingerService mocked to
+        // return null, never used in a query — so any non-null id is fine.
+        return User::factory()->make(['profile_id' => 1]);
+    }
+
+    public function test_bare_handle_reaches_webfinger_and_is_not_rejected_as_invalid_url(): void
+    {
+        $this->mock(WebfingerService::class, function ($mock) {
+            $mock->shouldReceive('findOrCreateRemoteActor')->andReturnNull();
+        });
+
+        $response = $this->actingAs($this->actingUser())
+            ->postJson('/api/v1/search/remote', ['q' => 'someone@example.com']);
+
+        // Before the fix this returned 403 "Invalid url"; now the handle is
+        // routed to WebFinger, which (mocked to find nothing) yields a clean
+        // "No remote account found" rather than a URL-validation error.
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', 'No remote account found');
+    }
+
+    public function test_hyphenated_handle_is_also_accepted(): void
+    {
+        $this->mock(WebfingerService::class, function ($mock) {
+            $mock->shouldReceive('findOrCreateRemoteActor')->andReturnNull();
+        });
+
+        $response = $this->actingAs($this->actingUser())
+            ->postJson('/api/v1/search/remote', ['q' => 'fa1ry-du5t@example.com']);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', 'No remote account found');
+    }
+
+    public function test_non_https_url_is_still_rejected_as_invalid_url(): void
+    {
+        // SSRF protection must be preserved: a real URL that fails the sanitiser
+        // (non-https / loopback) still aborts with 403 "Invalid url".
+        $response = $this->actingAs($this->actingUser())
+            ->postJson('/api/v1/search/remote', ['q' => 'http://127.0.0.1/admin']);
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Unit/IsRemoteQueryTest.php
+++ b/tests/Unit/IsRemoteQueryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\Api\SearchController;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Covers SearchController::isRemoteQuery() — the predicate that decides whether
+ * a search string should be resolved as a remote fediverse actor.
+ *
+ * Pure logic (regex / filter_var), so it runs without the app container or DB:
+ * the controller is created via newInstanceWithoutConstructor() and the
+ * protected method invoked by reflection.
+ */
+class IsRemoteQueryTest extends TestCase
+{
+    private function isRemoteQuery(string $query): bool
+    {
+        $ref = new ReflectionClass(SearchController::class);
+        $controller = $ref->newInstanceWithoutConstructor();
+        $method = $ref->getMethod('isRemoteQuery');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $query);
+    }
+
+    public function test_recognises_bare_handles(): void
+    {
+        $this->assertTrue($this->isRemoteQuery('mtv@divine.video'));
+        $this->assertTrue($this->isRemoteQuery('@mtv@divine.video'));
+        $this->assertTrue($this->isRemoteQuery('dansup@pixelfed.social'));
+    }
+
+    public function test_recognises_hyphenated_usernames(): void
+    {
+        // Regression: hyphens are valid in fediverse local-parts. Before the fix
+        // the username class was [a-zA-Z0-9_] and these returned false.
+        $this->assertTrue($this->isRemoteQuery('fa1ry-du5t@divine.video'));
+        $this->assertTrue($this->isRemoteQuery('x-x@example.com'));
+    }
+
+    public function test_recognises_urls(): void
+    {
+        $this->assertTrue($this->isRemoteQuery('https://divine.video/ap/users/mtv'));
+    }
+
+    public function test_rejects_plain_search_terms(): void
+    {
+        $this->assertFalse($this->isRemoteQuery('just a search'));
+        $this->assertFalse($this->isRemoteQuery('hashtag'));
+        $this->assertFalse($this->isRemoteQuery('nobody'));
+    }
+}


### PR DESCRIPTION
## Problem

Remote search rejects bare fediverse handles. Searching `user@domain` (e.g. `mtv@divine.video`) returns **403 "Invalid url"**, even though the account federates correctly — pasting the full actor URL (`https://divine.video/ap/users/mtv`) resolves the profile perfectly.

## Cause

In `SearchController@remoteLookup`, the URL-sanitisation gate runs **before** the bare-handle branch:

```php
$validUrl = app(SanitizeService::class)->url($query, true, false);
abort_if(! $validUrl, 403, 'Invalid url');

if (! filter_var($query, FILTER_VALIDATE_URL)) {
    // isRemoteQuery() + searchRemote() -> WebFinger  (never reached for a handle)
}
```

`SanitizeService::url()` requires an `https://` URL, so a bare handle is never a valid URL → it 403s before the handle-resolution branch (which `isRemoteQuery` is purpose-built to feed) can run. That branch is effectively dead code for handles.

## Fix

- Move the `url()` / `abort_if` gate **inside** the `filter_var($query, FILTER_VALIDATE_URL)` (URL) branch, so it only validates actual URLs. Bare handles now reach `searchRemote()` → WebFinger. SSRF protection for URL inputs is unchanged.
- Widen `isRemoteQuery()`'s username class `[a-zA-Z0-9_]` → `[a-zA-Z0-9_-]` so hyphenated usernames (e.g. `fa1ry-du5t@example.com`) are recognised — hyphens are valid in fediverse local-parts.

## Testing

- Before: `mtv@divine.video` → 403 "Invalid url".
- After: bare handle resolves via WebFinger; full actor URL still resolves; non-URL/non-handle junk still rejected.

No test coverage currently exists for `remoteLookup`'s handle path — happy to add a feature test if you'd like a particular shape.
