### PR TITLE
Starter kits: re-applying a kit can follow accounts that are blocked (or blocking)

### DIFF
--- a/app/Http/Controllers/Api/StarterKitController.php
+++ b/app/Http/Controllers/Api/StarterKitController.php
@@ -764,7 +764,6 @@ class StarterKitController extends Controller
 
             if (Follower::whereProfileId($pid)->whereFollowingId($account->id)->exists()) {
                 $alreadyFollowingCount++;
-
                 continue;
             }
 
@@ -853,6 +852,10 @@ class StarterKitController extends Controller
                 continue;
             }
 
+            if (UserFilterService::isBlocking($pid, $account->id)) {
+                continue;
+            }
+            
             if ($account->manuallyApprovesFollowers) {
                 continue;
             }

--- a/app/Http/Controllers/Api/StarterKitController.php
+++ b/app/Http/Controllers/Api/StarterKitController.php
@@ -855,7 +855,7 @@ class StarterKitController extends Controller
             if (UserFilterService::isBlocking($pid, $account->id)) {
                 continue;
             }
-            
+
             if ($account->manuallyApprovesFollowers) {
                 continue;
             }
@@ -868,7 +868,6 @@ class StarterKitController extends Controller
 
             if (Follower::whereProfileId($pid)->whereFollowingId($account->id)->exists()) {
                 $alreadyFollowingCount++;
-
                 continue;
             }
 


### PR DESCRIPTION
Add the isblocking check missing from reuse(). exists in use()