### PR TITLE
Update VideoObserver to clear video cache on status changes

### DIFF
--- a/app/Observers/VideoObserver.php
+++ b/app/Observers/VideoObserver.php
@@ -26,6 +26,11 @@ class VideoObserver
     {
         $this->updateProfileVideoCount($video->profile_id);
         AtomFeedService::invalidate($video->profile_id);
+
+        // Clear video media cache when status changes
+        if ($video->isDirty('status')) {
+            VideoService::deleteMediaData($video->id);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes... Duet videos can stay "not found" for 6 hours after publishing due to stale cache