### PR TITLE
AppServiceProvider: Respect FORCE_HTTPS env var

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -219,6 +219,8 @@ class AppServiceProvider extends ServiceProvider
 
     protected function configureSecureUrls()
     {
-        URL::forceHttps(true);
+        if (config('app.force_https')) {
+            URL::forceHttps(true);
+        }
     }
 }


### PR DESCRIPTION
Make HTTPS configurable via FORCE_HTTPS env var. If nothing is supplied, https is always enforced but can be disabled with `FORCE_HTTPS = False`.
This is useful for local development or testing.